### PR TITLE
Added option to put version number in package name dynamically.

### DIFF
--- a/munkipkg
+++ b/munkipkg
@@ -112,6 +112,12 @@ def read_build_info_plist(plist_path):
         raise BuildError(
             "%s is not a valid xml plist: %s" % (plist_path, str(err)))
     validate_build_info_keys(build_info, plist_path)
+    if '${version}' in build_info['name']:
+        build_info['name'] = build_info['name'].replace(
+            '${version}',
+            build_info['version']
+        )
+
     return build_info
 
 
@@ -125,6 +131,11 @@ def read_build_info_json(json_path):
         raise BuildError(
             "%s is not a valid json file: %s" % (json_path, str(err)))
     validate_build_info_keys(build_info, json_path)
+    if '${version}' in build_info['name']:
+        build_info['name'] = build_info['name'].replace(
+            '${version}',
+            build_info['version']
+        )
     return build_info
 
 


### PR DESCRIPTION
I think this accomplishes what we want without any weird side effects.

The name key looks like it is only use for the output file name, so it seems safe to inject the version number in there if a version variable is present in the original string:

```
	<key>name</key>
	<string>SuppressSetupAssistant-${version}.pkg</string>
	<key>version</key>
	<string>1.0</string>
```

Would become:

```
print(build_info['name'])
SuppressSetupAssistant-1.0.pkg
```