### PR TITLE
Distribution File Support

### DIFF
--- a/munkipkg
+++ b/munkipkg
@@ -239,7 +239,7 @@ def get_build_info(project_dir, options):
     supported_keys = ['name', 'identifier', 'version', 'ownership',
                       'install_location', 'postinstall_action',
                       'suppress_bundle_relocation',
-                      'distribution_style', 'signing_info']
+                      'distribution_style', 'signing_info','distribution']
     build_file = os.path.join(project_dir, BUILD_INFO_FILE)
     file_type = None
     if not options.yaml and not options.json:
@@ -555,7 +555,6 @@ def add_signing_options_to_cmd(cmd, build_info, options):
             else:
                 cmd.extend(['--timestamp=none'])
 
-
 def build_pkg(build_info, options):
     '''Use pkgbuild tool to build our package'''
     cmd = [PKGBUILD,
@@ -603,7 +602,14 @@ def build_distribution_pkg(build_info, options):
         build_info['project_dir'], REQUIREMENTS_PLIST)
     if os.path.exists(requirements_plist):
         cmd.extend(['--product', requirements_plist])
-    cmd.extend(['--package', pkginputname, distoutputname])
+    if 'distribution' in build_info:
+        distributionname = os.path.join(build_info['project_dir'], build_info['distribution']['name'])
+        if os.path.exists(distributionname):
+            cmd.extend(['--distribution', distributionname])
+            cmd.extend(['--resources', build_info['distribution']['resources']])
+            cmd.extend(['--package-path', build_info['build_dir'], distoutputname])
+    else:
+        cmd.extend(['--package', pkginputname, distoutputname])
 
     retcode = subprocess.call(cmd)
     if retcode:


### PR DESCRIPTION
One can add a distribution file in build-info.json:

```json
    "distribution": {
        "name": "distribution.xml",
        "resources": "path/to/resources"
    }
```

distribution.xml
```xml
<?xml version="1.0" encoding="utf-8"?>
<installer-gui-script minSpecVersion="2">
    <pkg-ref id="@IDENTIFIER@"/>
    <allowed-os-versions>
    	<os-version min="10.12" />
	</allowed-os-versions>
    <options customize="never" require-scripts="false" rootVolumeOnly="true" />
    <choices-outline>
        <line choice="default">
            <line choice="@IDENTIFIER@"/>
        </line>
    </choices-outline>
    <choice id="default"/>
    <choice id="@IDENTIFIER@" visible="false">
        <pkg-ref id="@IDENTIFIER@"/>
    </choice>
    <pkg-ref id="@IDENTIFIER@" version="@VERSION@" onConclusion="none">@PKG@.pkg</pkg-ref>
    <title>App Title</title>
</installer-gui-script>
```