### PR TITLE
add SetupAssistantLanguageChooser

### DIFF
--- a/SetupAssistantLanguageChooser/.gitignore
+++ b/SetupAssistantLanguageChooser/.gitignore
@@ -1,0 +1,5 @@
+# .DS_Store files!
+.DS_Store
+
+# our build directory
+build/

--- a/SetupAssistantLanguageChooser/build-info.plist
+++ b/SetupAssistantLanguageChooser/build-info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>distribution_style</key>
+	<true/>
+	<key>identifier</key>
+	<string>com.github.munki.pkg.SetupAssistantLanguageChooser</string>
+	<key>install_location</key>
+	<string>/</string>
+	<key>name</key>
+	<string>SetupAssistantLanguageChooser.pkg</string>
+	<key>ownership</key>
+	<string>recommended</string>
+	<key>postinstall_action</key>
+	<string>none</string>
+	<key>suppress_bundle_relocation</key>
+	<true/>
+	<key>version</key>
+	<string>1.0</string>
+</dict>
+</plist>


### PR DESCRIPTION
I'd like to add a simple pkg for the SetupAssistant Language configuration.

I'll be working on a blog post shortly and while I have no problem hosting this myself, it's harmless enough (and a great example) for the main munki-pkg repo.