### PR TITLE
Specify yaml loader

### DIFF
--- a/munkipkg
+++ b/munkipkg
@@ -119,7 +119,7 @@ def read_build_info(path):
                 build_info = json.load(openfile)
         elif path.endswith(('.yaml', '.yml')):
             with open(path, 'r') as openfile:
-                build_info = yaml.load(openfile)
+                build_info = yaml.load(openfile, Loader=yaml.FullLoader)
         elif path.endswith('.plist'):
             build_info = plistlib.readPlist(path)
     except (ExpatError, ValueError, yaml.scanner.ScannerError) as err:


### PR DESCRIPTION
There was a warning when using YAML files with `munkipkg`:

```
/usr/local/bin/munkipkg:122: YAMLLoadWarning: 
  *** Calling yaml.load() without Loader=... is deprecated.
  *** The default Loader is unsafe.
  *** Please read https://msg.pyyaml.org/load for full details.
  build_info = yaml.load(openfile)
```

This PR fixes the issue described in pyyaml [wiki](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation).