### PR TITLE
Specify yaml loader

### DIFF
--- a/munkipkg
+++ b/munkipkg
@@ -119,7 +119,7 @@ def read_build_info(path):
                 build_info = json.load(openfile)
         elif path.endswith(('.yaml', '.yml')):
             with open(path, 'r') as openfile:
-                build_info = yaml.load(openfile)
+                build_info = yaml.load(openfile, Loader=yaml.FullLoader)
         elif path.endswith('.plist'):
             build_info = plistlib.readPlist(path)
     except (ExpatError, ValueError, yaml.scanner.ScannerError) as err:


### PR DESCRIPTION
Resolves this warning encountered during package build:
```
/usr/local/bin/munkipkg:122: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```