### PR TITLE
Change munki_kickstart identifier

### DIFF
--- a/munki_kickstart/build-info.json
+++ b/munki_kickstart/build-info.json
@@ -1,7 +1,7 @@
 {
     "ownership": "recommended",
     "suppress_bundle_relocation": true,
-    "identifier": "com.github.munki.pkg.munki_kickstart",
+    "identifier": "com.github.munki.pkg.munki-kickstart",
     "postinstall_action": "none",
     "distribution_style": true,
     "version": "1.0",


### PR DESCRIPTION
When I tried to upload package with the identifier  `something.pkg.munki_kickstart` to Apple notary service they did not like the identifier.

It might be good to have non problematic identifier in the example.