### PR TITLE
Always cast version as a string before using

### DIFF
--- a/munkipkg
+++ b/munkipkg
@@ -43,7 +43,7 @@ except ImportError:
 from xml.dom import minidom
 from xml.parsers.expat import ExpatError
 
-VERSION = "0.6"
+VERSION = "0.7"
 DITTO = "/usr/bin/ditto"
 LSBOM = "/usr/bin/lsbom"
 PKGBUILD = "/usr/bin/pkgbuild"
@@ -155,7 +155,7 @@ def read_build_info(path):
     if '${version}' in build_info['name']:
         build_info['name'] = build_info['name'].replace(
             '${version}',
-            build_info['version']
+            str(build_info['version'])
         )
 
     return build_info
@@ -562,7 +562,7 @@ def build_pkg(build_info, options):
     cmd = [PKGBUILD,
            '--ownership', build_info['ownership'],
            '--identifier', build_info['identifier'],
-           '--version', build_info['version'],
+           '--version', str(build_info['version']),
            '--info', build_info['pkginfo_path']]
     if build_info['payload']:
         cmd.extend(['--root', build_info['payload']])
@@ -607,7 +607,7 @@ def build_distribution_pkg(build_info, options):
     # if build_info contains a product id use that for product id, otherwise
     # use package identifier
     product_id = build_info.get('product id', build_info['identifier'])
-    cmd.extend(['--identifier', product_id, '--version', build_info['version']])
+    cmd.extend(['--identifier', product_id, '--version', str(build_info['version'])])
     # add the input and output package paths
     cmd.extend(['--package', pkginputname, distoutputname])
 


### PR DESCRIPTION
This change makes MunkiPkg more resilient against improperly formatted build-info files where the `version` may not be interpreted as a string.

## Problem

Currently, if the `version` is not interpreted as a string, MunkiPkg fails to build the package and produces a traceback.

This problem state is difficult to get into accidentally if one is using a plist build-info file, as is the default, because the plist specifies `<string>` as the version type in an obvious manner. However, with either YAML or JSON build-info files, entering this error state is as simple as omitting quotes:

YAML:

```yaml
version: 1.1
```

JSON:

```json
"version": 1.1,
```

## Solution

Casting the version with `str( )` each time it's referenced prior to packaging ensures that MunkiPkg gracefully handles an improper version type in the build-info file.

## Testing

In all tests below, an installation of [MacAdmins managed Python 3](https://github.com/macadmins/python) has been used as the interpreter for MunkiPkg.

### Correctly formatted plist, before

Build-info version:

```
	<key>version</key>
	<string>1.1</string>
```

Test output:

```
% git checkout main
Switched to branch 'main'
Your branch is up to date with 'upstream/main'.
% managed_python3 munkipkg plist_test 
pkgbuild: Inferring bundle components from contents of plist_test/payload
pkgbuild: Writing new component property list to /var/folders/jj/4ykdc7714tq8jwb25_j8czxh0000gn/T/tmpx4kniity/component.plist
pkgbuild: Reading components from /var/folders/jj/4ykdc7714tq8jwb25_j8czxh0000gn/T/tmpx4kniity/component.plist
pkgbuild: Wrote package to plist_test/build/plist_test-1.1.pkg
```

### Correctly formatted plist, after

Test output:

```
% git checkout version-strings       
Switched to branch 'version-strings'
Your branch is up to date with 'origin/version-strings'.
% managed_python3 munkipkg plist_test
pkgbuild: Inferring bundle components from contents of plist_test/payload
pkgbuild: Writing new component property list to /var/folders/jj/4ykdc7714tq8jwb25_j8czxh0000gn/T/tmpnihd6fep/component.plist
pkgbuild: Reading components from /var/folders/jj/4ykdc7714tq8jwb25_j8czxh0000gn/T/tmpnihd6fep/component.plist
pkgbuild: Wrote package to plist_test/build/plist_test-1.1.pkg
```

### Incorrectly formatted plist, before

Build-info version:

```
	<key>version</key>
	<integer>2</integer>
```

Test output:

```
% git checkout main                                 
Switched to branch 'main'
Your branch is up to date with 'upstream/main'.
% managed_python3 munkipkg plist_test
Traceback (most recent call last):
  File "munkipkg", line 1056, in <module>
    main()
  File "munkipkg", line 1052, in main
    result = build(arguments[0], options)
  File "munkipkg", line 633, in build
    build_info = get_build_info(project_dir, options)
  File "munkipkg", line 260, in get_build_info
    file_info = read_build_info(build_file + '.' + file_type)
  File "munkipkg", line 156, in read_build_info
    build_info['name'] = build_info['name'].replace(
TypeError: replace() argument 2 must be str, not int
```

### Incorrectly formatted plist, after

Test output:

```
% git checkout version-strings
Switched to branch 'version-strings'
Your branch is up to date with 'origin/version-strings'.
% managed_python3 munkipkg plist_test 
pkgbuild: Inferring bundle components from contents of plist_test/payload
pkgbuild: Writing new component property list to /var/folders/jj/4ykdc7714tq8jwb25_j8czxh0000gn/T/tmp02gy3hp5/component.plist
pkgbuild: Reading components from /var/folders/jj/4ykdc7714tq8jwb25_j8czxh0000gn/T/tmp02gy3hp5/component.plist
pkgbuild: Wrote package to plist_test/build/plist_test-2.pkg
```

### Correctly formatted json, before

Build-info version:

```
    "version": "1.1",
```

Test output:

```
% git checkout main
Switched to branch 'main'
Your branch is up to date with 'upstream/main'.
% managed_python3 munkipkg json_test
pkgbuild: Inferring bundle components from contents of json_test/payload
pkgbuild: Writing new component property list to /var/folders/jj/4ykdc7714tq8jwb25_j8czxh0000gn/T/tmpb6f7yhyh/component.plist
pkgbuild: Reading components from /var/folders/jj/4ykdc7714tq8jwb25_j8czxh0000gn/T/tmpb6f7yhyh/component.plist
pkgbuild: Wrote package to json_test/build/json_test-1.1.pkg
```

### Correctly formatted json, after

Test output:

```
% git checkout version-strings
Switched to branch 'version-strings'
Your branch is up to date with 'origin/version-strings'.
% managed_python3 munkipkg json_test 
pkgbuild: Inferring bundle components from contents of json_test/payload
pkgbuild: Writing new component property list to /var/folders/jj/4ykdc7714tq8jwb25_j8czxh0000gn/T/tmp8nxykihh/component.plist
pkgbuild: Reading components from /var/folders/jj/4ykdc7714tq8jwb25_j8czxh0000gn/T/tmp8nxykihh/component.plist
pkgbuild: Wrote package to json_test/build/json_test-1.1.pkg
```

### Incorrectly formatted json, before

Build-info version:

```
    "version": 1.1,
```

Test output:

```
% git checkout main                                 
Switched to branch 'main'
Your branch is up to date with 'upstream/main'.
% managed_python3 munkipkg json_test
Traceback (most recent call last):
  File "munkipkg", line 1056, in <module>
    main()
  File "munkipkg", line 1052, in main
    result = build(arguments[0], options)
  File "munkipkg", line 633, in build
    build_info = get_build_info(project_dir, options)
  File "munkipkg", line 260, in get_build_info
    file_info = read_build_info(build_file + '.' + file_type)
  File "munkipkg", line 156, in read_build_info
    build_info['name'] = build_info['name'].replace(
TypeError: replace() argument 2 must be str, not float
```

### Incorrectly formatted json, after

Test output:

```
% git checkout version-strings
Switched to branch 'version-strings'
Your branch is up to date with 'origin/version-strings'.
% managed_python3 munkipkg json_test 
pkgbuild: Inferring bundle components from contents of json_test/payload
pkgbuild: Writing new component property list to /var/folders/jj/4ykdc7714tq8jwb25_j8czxh0000gn/T/tmp0bm1dzzw/component.plist
pkgbuild: Reading components from /var/folders/jj/4ykdc7714tq8jwb25_j8czxh0000gn/T/tmp0bm1dzzw/component.plist
pkgbuild: Wrote package to json_test/build/json_test-1.1.pkg
```

### Correctly formatted yaml, before

Build-info version:

```
version: '1.1'
```

Test output:

```
% git checkout main
Switched to branch 'main'
Your branch is up to date with 'upstream/main'.
% managed_python3 munkipkg yaml_test
pkgbuild: Inferring bundle components from contents of yaml_test/payload
pkgbuild: Writing new component property list to /var/folders/jj/4ykdc7714tq8jwb25_j8czxh0000gn/T/tmpxtug9a6h/component.plist
pkgbuild: Reading components from /var/folders/jj/4ykdc7714tq8jwb25_j8czxh0000gn/T/tmpxtug9a6h/component.plist
pkgbuild: Wrote package to yaml_test/build/yaml_test-1.1.pkg
```

### Correctly formatted yaml, after

Test output:

```
% git checkout version-strings      
Switched to branch 'version-strings'
Your branch is up to date with 'origin/version-strings'.
% managed_python3 munkipkg yaml_test
pkgbuild: Inferring bundle components from contents of yaml_test/payload
pkgbuild: Writing new component property list to /var/folders/jj/4ykdc7714tq8jwb25_j8czxh0000gn/T/tmpex93stac/component.plist
pkgbuild: Reading components from /var/folders/jj/4ykdc7714tq8jwb25_j8czxh0000gn/T/tmpex93stac/component.plist
pkgbuild: Wrote package to yaml_test/build/yaml_test-1.1.pkg
```

### Incorrectly formatted yaml, before

Build-info version:

```
version: 1.1
```

Test output:

```
% git checkout main                                 
Switched to branch 'main'
Your branch is up to date with 'upstream/main'.
% managed_python3 munkipkg yaml_test 
Traceback (most recent call last):
  File "munkipkg", line 1056, in <module>
    main()
  File "munkipkg", line 1052, in main
    result = build(arguments[0], options)
  File "munkipkg", line 633, in build
    build_info = get_build_info(project_dir, options)
  File "munkipkg", line 260, in get_build_info
    file_info = read_build_info(build_file + '.' + file_type)
  File "munkipkg", line 156, in read_build_info
    build_info['name'] = build_info['name'].replace(
TypeError: replace() argument 2 must be str, not float
```

### Incorrectly formatted yaml, after

Test output:

```
% git checkout version-strings
Switched to branch 'version-strings'
Your branch is up to date with 'origin/version-strings'.
% managed_python3 munkipkg yaml_test 
pkgbuild: Inferring bundle components from contents of yaml_test/payload
pkgbuild: Writing new component property list to /var/folders/jj/4ykdc7714tq8jwb25_j8czxh0000gn/T/tmp95zso26y/component.plist
pkgbuild: Reading components from /var/folders/jj/4ykdc7714tq8jwb25_j8czxh0000gn/T/tmp95zso26y/component.plist
pkgbuild: Wrote package to yaml_test/build/yaml_test-1.1.pkg
```
