### PR TITLE
fixed ./payload/. does not exist error

### DIFF
--- a/munkipkg
+++ b/munkipkg
@@ -414,7 +414,7 @@ def sync_from_bom_info(project_dir, options):
                     display("Creating %s with mode %s"
                             % (payload_path, oct(desired_mode)),
                             options.quiet)
-                    os.mkdir(payload_path, desired_mode)
+                    os.makedirs(payload_path, desired_mode)
                     changes_made += 1
                     continue
                 else:


### PR DESCRIPTION
munkipkg --sync would fail on pseudo-payload-free package projects cloned from git repositories because os.mkdir(./payload/.) would fail, because the parent directory of ./payload/., ./payload, did not exist. Fixed this
by changing os.mkdir to os.makedirs, which creates directories recursively analogously to mkdir -p.