### PR TITLE
Change shebang to reference munki-python

### DIFF
--- a/munkipkg
+++ b/munkipkg
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/munki/munki-python
 # encoding: utf-8
 """
 munkipkg


### PR DESCRIPTION
Support for upcoming macOS 12.3 -- initial testing on my end seems it just works with new shebang. Can others confirm? Thanks.