### PR TITLE
Add support for latest compression via min-os-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,11 +208,10 @@ Dictionary of notarization options. See below.
 #### build-info keys supported by macOS 12+
 
 **compression**  
-String. `latest` or `legacy`. Use `latest` in conjunction with `min-os-version` of `10.10` or newer for better .pkg compression.
+String. One of "latest" or "legacy". When creating pkg files on macOS 12 or higher, using "latest" in conjunction with a `min-os-version` of `10.10` (or higher) will result in increased compression of pkg content.
 
 **min-os-version**  
-String. Set to 10.10+ to enable better compression.
-
+String. Numeric representation of the target OS's MAJOR.MINOR versions. Eg "10.5", "10.10", "12.0", etc
 
 ### Build directory
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,14 @@ Dictionary of signing options. See below.
 **notarization_info**  
 Dictionary of notarization options. See below.
 
+#### build-info keys supported by macOS 12+
+
+**compression**  
+String. `latest` or `legacy`. Use `latest` in conjunction with `min-os-version` of `10.10` or newer for better .pkg compression.
+
+**min-os-version**  
+String. Set to 10.10+ to enable better compression.
+
 
 ### Build directory
 

--- a/munkipkg
+++ b/munkipkg
@@ -150,6 +150,7 @@ def run_subprocess(cmd):
 def validate_build_info_keys(build_info, file_path):
     '''Validates the data read from build_info.(plist|json|yaml|yml)'''
     valid_values = {
+        'compression': ['legacy', 'latest'],
         'ownership': ['recommended', 'preserve', 'preserve-other'],
         'postinstall_action': ['none', 'logout', 'restart'],
         'suppress_bundle_relocation': [True, False],

--- a/munkipkg
+++ b/munkipkg
@@ -272,11 +272,13 @@ def get_build_info(project_dir, options):
     info['project_dir'] = project_dir
     # override default values with values from BUILD_INFO_PLIST
     supported_keys = [
+        'compression',
         'name',
         'identifier',
         'version',
         'ownership',
         'install_location',
+        'min-os-version',
         'postinstall_action',
         'preserve_xattr',
         'suppress_bundle_relocation',
@@ -614,8 +616,12 @@ def build_pkg(build_info, options):
             cmd.extend(['--install-location', build_info['install_location']])
     else:
         cmd.extend(['--nopayload'])
+    if build_info['compression']:
+        cmd.extend(['--compression', build_info['compression']])
     if build_info['component_plist']:
         cmd.extend(['--component-plist', build_info['component_plist']])
+    if build_info['min-os-version']:
+        cmd.extend(['--min-os-version', build_info['min-os-version']])
     if build_info['scripts']:
         cmd.extend(['--scripts', build_info['scripts']])
     if options.quiet:


### PR DESCRIPTION
I was creating a large pkg, and my go-to tooling doesn't support Apple's "new" compression options.

I read about "[This one weird Monterrey trick](https://scriptingosx.com/2021/10/save-up-to-25-pkg-file-size-with-this-weird-monterey-trick/)" and added it to munki-pkg.


I am not sure that there would be differences in workflows by setting 10.5 & legacy, but this does change default behavior by adding two keys, even if not defined by the user. I set the defaults so as not to interrupt any workflows.

In my project file, I set them to min-os-version 10.10 and compression to latest, the resulting .pkg was 31MB vs 49MB.

