### PR TITLE
[notarytool branch] Fix notarization based on apple_id and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,10 +293,12 @@ You may notarize **SIGNED PACKAGES** as part of the build process by adding a `n
 ```xml
     <key>notarization_info</key>
     <dict>
-        <key>username</key>
+        <key>apple_id</key>
         <string>john.appleseed@apple.com</string>
         <key>password</key>
         <string>@keychain:AC_PASSWORD</string>
+        <key>team_id</key>
+        <string>ABCDEF12345</string>
         <key>asc_provider</key>
         <string>JohnAppleseed1XXXXXX8</string>
         <key>staple_timeout</key>
@@ -319,17 +321,17 @@ Keys/values of the `notarization_info` dictionary:
 
 | Key               | Type    | Required | Description |
 | ----------------- | ------- | -------- | ----------- |
-| username          | String  | Yes      | Login email address of your developer Apple ID |
+| apple_id          | String  | (see authentication) | Login email address of your developer Apple ID |
+| team_id           | String  | (see authentication) | The team identifier for the Developer Team, usually 10 alphanumeric characters |
 | password          | String  | (see authentication) | 2FA app specific password. |
-| api_key           | String  | (see authentication) | App Store Connect API access key. |
-| api_issuer        | String  | (see authentication) | App Store Connect API key issuer ID. |
+| keychain_profile  | String  | (see authentication) | App Store Connect API key issuer ID. |
 | asc_provider      | String  | No       | Only needed when a user account is associated with multiple providers |
 | primary_bundle_id | String  | No       | Defaults to `identifier`. Whether specified or not underscore characters are always automatically converted to hyphens since Apple notary service does not like underscores |
 | staple_timeout    | Integer | No       | See paragraph bellow |
 
 **Authentication**  
 
-To notarize the package you have to use Apple ID with access to App Store Connect. There are two possible authentication methods: App-specific password and API key. Either `password` or `api_key` + `api_issuer` keys(s) **must** be specified in the `notarization_info` dictionary. If you specify both `password` takes precedence.
+To notarize the package you have to use Apple ID with access to App Store Connect. There are two possible authentication methods: App-specific password and keychain profile. Either `apple_id`+`team_id`+`password` or `keychain_profile` keys(s) **must** be specified in the `notarization_info` dictionary. If you specify both `password` based takes precedence.
 
 **Using the password**  
 
@@ -391,8 +393,8 @@ All your munkipkg json project files will need that notarization info added as s
 
 `munki-pkg` basically does following:
 
-1. Uploads the package to Apple notary service using `xcrun altool --notarize-app --primary-bundle-id "com.github.munki.pkg.munki-kickstart" --username "john.appleseed@apple.com" --password "@keychain:AC_PASSWORD" --file munki_kickstart.pkg`
-2. Checks periodically state of notarization process using `xcrun altool --notarization-info <UUID> --username "john.appleseed@apple.com" --password "@keychain:AC_PASSWORD"`
+1. Uploads the package to Apple notary service using `xcrun notarytool submit --output-format plist build/munki_kickstart.pkg --apple-id "john.appleseed@apple.com" --team-id ABCDEF12345 --password "@keychain:AC_PASSWORD"`
+2. Checks periodically state of notarization process using `xcrun notarytool info <UUID> --output-format plist --apple-id "john.appleseed@apple.com" --team-id ABCDEF12345 --password "@keychain:AC_PASSWORD"`
 3. If notarization was successful `munki-pkg` staples the package using `xcrun stapler staple munki_kickstart.pkg`
 
 There is a time delay between successful upload of a signed package to the notary service and notarization result from the service.

--- a/munkipkg
+++ b/munkipkg
@@ -803,11 +803,9 @@ def notarization_done(state, sleep_time, options):
     else:
         display(
             "Notarization unsuccessful:\n"
-            "\tStatus: {}\n"
-            "\tStatus Code: {}\n"
-            "\tStatus Message: {}\n"
-            "\tLogFileURL: {}".format(
-                state['status'], state['code'], state['message'], state['log_url']
+            "\tStatus(id={}): {}\n"
+            "\tStatus Message: {}".format(
+                state['id'], state['status'], state['message']
             ),
             options.quiet,
         )

--- a/munkipkg
+++ b/munkipkg
@@ -737,7 +737,7 @@ def upload_to_notary(build_info, options):
                 file=sys.stderr
             )
         raise MunkiPkgError("Notarization failed")
-    
+
     try:
         request_id = output['id']
         display("id " + request_id, options.quiet, "notarytool")
@@ -760,7 +760,7 @@ def get_notarization_state(request_id, build_info, options):
         'plist',
     ]
     add_authentication_options(cmd, build_info)
-    
+
     retcode, proc_stdout, proc_stderr = run_subprocess(cmd)
     if proc_stdout.startswith('Generated JWT'):
         proc_stdout = proc_stdout.split('\n',1)[1]

--- a/munkipkg
+++ b/munkipkg
@@ -685,11 +685,15 @@ def add_authentication_options(cmd, build_info):
     '''Add --password or --apiKey + --apiIssuer options to the command'''
     if (
         'apple_id' in build_info['notarization_info'] and
+        'team_id' in build_info['notarization_info'] and
         'password' in build_info['notarization_info']
     ):
         cmd.extend(
-            '--apple-id', build_info['notarization_info']['apple_id'],
-            '--password', build_info['notarization_info']['password']
+            [
+                '--apple-id', build_info['notarization_info']['apple_id'],
+                '--team-id', build_info['notarization_info']['team_id'],
+                '--password', build_info['notarization_info']['password']
+            ]
         )
     elif (
           'keychain_profile' in build_info['notarization_info']
@@ -702,7 +706,7 @@ def add_authentication_options(cmd, build_info):
         )
     else:
         raise MunkiPkgError(
-            "apple_id + password or keychain_profile"
+            "apple_id + team_id + password or keychain_profile"
             "must be specified in notarization_info."
         )
 
@@ -722,28 +726,24 @@ def upload_to_notary(build_info, options):
     add_authentication_options(cmd, build_info)
 
     retcode, proc_stdout, proc_stderr = run_subprocess(cmd)
+    if retcode:
+        print("notarytool: " + proc_stderr, file=sys.stderr)
+        raise MunkiPkgError("Notarization upload failed.")
+
     if proc_stdout.startswith('Generated JWT'):
         proc_stdout = proc_stdout.split('\n',1)[1]
     try:
         output = readPlistFromString(proc_stdout.encode("UTF-8"))
     except ExpatError:
-        print(proc_stderr, file=sys.stderr)
-        raise MunkiPkgError("Notarization upload failed. Unable to run xcrun altool")
-
-    if retcode:
-        for product_error in output.get('product-errors', []):
-            print(
-                "altool: FAILURE " + product_error.get('message', 'UNKNOWN ERROR'),
-                file=sys.stderr
-            )
-        raise MunkiPkgError("Notarization failed")
+        print("notarytool: " + proc_stderr, file=sys.stderr)
+        raise MunkiPkgError("Notarization upload failed.")
 
     try:
         request_id = output['id']
         display("id " + request_id, options.quiet, "notarytool")
         display(output['message'], options.quiet, "notarytool")
     except KeyError:
-        raise MunkiPkgError("Unexpected output from altool")
+        raise MunkiPkgError("Unexpected output from notarytool")
 
     return request_id
 
@@ -762,6 +762,10 @@ def get_notarization_state(request_id, build_info, options):
     add_authentication_options(cmd, build_info)
 
     retcode, proc_stdout, proc_stderr = run_subprocess(cmd)
+    if retcode:
+        print("notarytool: " + proc_stderr, file=sys.stderr)
+        raise MunkiPkgError("Notarization check failed.")
+
     if proc_stdout.startswith('Generated JWT'):
         proc_stdout = proc_stdout.split('\n',1)[1]
 
@@ -769,10 +773,10 @@ def get_notarization_state(request_id, build_info, options):
         output = readPlistFromString(proc_stdout.encode("UTF-8"))
     except ExpatError:
         print(proc_stderr, file=sys.stderr)
-        raise MunkiPkgError("Notarization check failed. Unable to run xcrun notarytool")
-    if retcode or 'message' not in output:
-        print("altool: " + output.get('success-message', 'Unexpected response'))
-        print("altool: DEBUG output follows")
+        raise MunkiPkgError("Notarization check failed.")
+    if 'message' not in output:
+        print("notarytool: " + output.get('success-message', 'Unexpected response'))
+        print("notarytool: DEBUG output follows")
         print(output)
         state['status'] = 'Unknown'
     else:


### PR DESCRIPTION
Make `team_id` is also required as we must set `--team-id` option together with `--apple-id` & `--password`
Fix command error handling so we have a clear error on wrong credentials
Removed all altool old references
Try to update README with updated notarization support
It also fixes #69