### PR TITLE
Fixed trailing space in error message, and merge notary tool branch to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,47 @@ For information about the password and saving it to the login keychain see the w
 
 If you configure `munki-pkg` to use the password from the login keychain user is going to be prompted to allow access to the password. You can authorize this once clicking *Allow* or permanently clicking *Always Allow*.
 
+**How to Setup Your Keychain for Notarization with `notarytool`**
+
+Dependency: `notarytool` is bundled with Xcode, so you need to have the latest version of Xcode installed and the command line tools.
+
+Run: 
+`/Applications/Xcode.app/Contents/Developer/usr/bin/notarytool store-credentials` 
+
+It will ask you for a profile name, use: `notarization_credentials` as that is what all our pkginfo files will have as the `keychain_profile` key in the munki-pkg project json file, as such:
+
+Skip the next question about App Store API.
+
+1. It will move to ask you for a Developer Apple ID email
+2. The password here is a unique app-specific password created in appleid.apple.com from the same Developer ID account.
+3. Enter your Team ID from the developer certificate.
+
+All your munkipkg json project files will need that notarization info added as such:
+
+```
+{
+    "postinstall_action": "none",
+    "suppress_bundle_relocation": true,
+    "name": "PackageName.pkg",
+    "distribution_style": true,
+    "install_location": "/path/to/payload/location/",
+    "version": "14.0",
+    "ownership": "recommended",
+    "identifier": "com.domain.PackageName",
+    "signing_info": {
+        "identity": "Developer ID Installer: Company Name (Team ID)",
+        "keychain": "/path/to/certificate/signing.keychain",
+        "timestamp": true
+    },
+    "notarization_info": {
+        "keychain_profile": "notarization_credentials"
+    }
+}
+```
+
+`munki-pkg` will now call the `keychain_profile` from the json to run as the credentials for the notarization.
+
+
 **Creating the API key**  
 
 1. Log into [App Store Connect](https://appstoreconnect.apple.com) using developer Apple ID with access to API keys.

--- a/README.md
+++ b/README.md
@@ -293,10 +293,12 @@ You may notarize **SIGNED PACKAGES** as part of the build process by adding a `n
 ```xml
     <key>notarization_info</key>
     <dict>
-        <key>username</key>
+        <key>apple_id</key>
         <string>john.appleseed@apple.com</string>
         <key>password</key>
         <string>@keychain:AC_PASSWORD</string>
+        <key>team_id</key>
+        <string>ABCDEF12345</string>
         <key>asc_provider</key>
         <string>JohnAppleseed1XXXXXX8</string>
         <key>staple_timeout</key>
@@ -319,17 +321,17 @@ Keys/values of the `notarization_info` dictionary:
 
 | Key               | Type    | Required | Description |
 | ----------------- | ------- | -------- | ----------- |
-| username          | String  | Yes      | Login email address of your developer Apple ID |
+| apple_id          | String  | (see authentication) | Login email address of your developer Apple ID |
+| team_id           | String  | (see authentication) | The team identifier for the Developer Team, usually 10 alphanumeric characters |
 | password          | String  | (see authentication) | 2FA app specific password. |
-| api_key           | String  | (see authentication) | App Store Connect API access key. |
-| api_issuer        | String  | (see authentication) | App Store Connect API key issuer ID. |
+| keychain_profile  | String  | (see authentication) | App Store Connect API key issuer ID. |
 | asc_provider      | String  | No       | Only needed when a user account is associated with multiple providers |
 | primary_bundle_id | String  | No       | Defaults to `identifier`. Whether specified or not underscore characters are always automatically converted to hyphens since Apple notary service does not like underscores |
 | staple_timeout    | Integer | No       | See paragraph bellow |
 
 **Authentication**  
 
-To notarize the package you have to use Apple ID with access to App Store Connect. There are two possible authentication methods: App-specific password and API key. Either `password` or `api_key` + `api_issuer` keys(s) **must** be specified in the `notarization_info` dictionary. If you specify both `password` takes precedence.
+To notarize the package you have to use Apple ID with access to App Store Connect. There are two possible authentication methods: App-specific password and keychain profile. Either `apple_id`+`team_id`+`password` or `keychain_profile` keys(s) **must** be specified in the `notarization_info` dictionary. If you specify both `password` based takes precedence.
 
 **Using the password**  
 
@@ -391,8 +393,8 @@ All your munkipkg json project files will need that notarization info added as s
 
 `munki-pkg` basically does following:
 
-1. Uploads the package to Apple notary service using `xcrun altool --notarize-app --primary-bundle-id "com.github.munki.pkg.munki-kickstart" --username "john.appleseed@apple.com" --password "@keychain:AC_PASSWORD" --file munki_kickstart.pkg`
-2. Checks periodically state of notarization process using `xcrun altool --notarization-info <UUID> --username "john.appleseed@apple.com" --password "@keychain:AC_PASSWORD"`
+1. Uploads the package to Apple notary service using `xcrun notarytool submit --output-format plist build/munki_kickstart.pkg --apple-id "john.appleseed@apple.com" --team-id ABCDEF12345 --password "@keychain:AC_PASSWORD"`
+2. Checks periodically state of notarization process using `xcrun notarytool info <UUID> --output-format plist --apple-id "john.appleseed@apple.com" --team-id ABCDEF12345 --password "@keychain:AC_PASSWORD"`
 3. If notarization was successful `munki-pkg` staples the package using `xcrun stapler staple munki_kickstart.pkg`
 
 There is a time delay between successful upload of a signed package to the notary service and notarization result from the service.

--- a/munkipkg
+++ b/munkipkg
@@ -685,11 +685,15 @@ def add_authentication_options(cmd, build_info):
     '''Add --password or --apiKey + --apiIssuer options to the command'''
     if (
         'apple_id' in build_info['notarization_info'] and
+        'team_id' in build_info['notarization_info'] and
         'password' in build_info['notarization_info']
     ):
         cmd.extend(
-            '--apple-id', build_info['notarization_info']['apple_id'],
-            '--password', build_info['notarization_info']['password']
+            [
+                '--apple-id', build_info['notarization_info']['apple_id'],
+                '--team-id', build_info['notarization_info']['team_id'],
+                '--password', build_info['notarization_info']['password']
+            ]
         )
     elif (
           'keychain_profile' in build_info['notarization_info']
@@ -702,7 +706,7 @@ def add_authentication_options(cmd, build_info):
         )
     else:
         raise MunkiPkgError(
-            "apple_id + password or keychain_profile"
+            "apple_id + team_id + password or keychain_profile"
             "must be specified in notarization_info."
         )
 
@@ -722,28 +726,24 @@ def upload_to_notary(build_info, options):
     add_authentication_options(cmd, build_info)
 
     retcode, proc_stdout, proc_stderr = run_subprocess(cmd)
+    if retcode:
+        print("notarytool: " + proc_stderr, file=sys.stderr)
+        raise MunkiPkgError("Notarization upload failed.")
+
     if proc_stdout.startswith('Generated JWT'):
         proc_stdout = proc_stdout.split('\n',1)[1]
     try:
         output = readPlistFromString(proc_stdout.encode("UTF-8"))
     except ExpatError:
-        print(proc_stderr, file=sys.stderr)
-        raise MunkiPkgError("Notarization upload failed. Unable to run xcrun altool")
+        print("notarytool: " + proc_stderr, file=sys.stderr)
+        raise MunkiPkgError("Notarization upload failed.")
 
-    if retcode:
-        for product_error in output.get('product-errors', []):
-            print(
-                "altool: FAILURE " + product_error.get('message', 'UNKNOWN ERROR'),
-                file=sys.stderr
-            )
-        raise MunkiPkgError("Notarization failed")
-    
     try:
         request_id = output['id']
         display("id " + request_id, options.quiet, "notarytool")
         display(output['message'], options.quiet, "notarytool")
     except KeyError:
-        raise MunkiPkgError("Unexpected output from altool")
+        raise MunkiPkgError("Unexpected output from notarytool")
 
     return request_id
 
@@ -760,8 +760,12 @@ def get_notarization_state(request_id, build_info, options):
         'plist',
     ]
     add_authentication_options(cmd, build_info)
-    
+
     retcode, proc_stdout, proc_stderr = run_subprocess(cmd)
+    if retcode:
+        print("notarytool: " + proc_stderr, file=sys.stderr)
+        raise MunkiPkgError("Notarization check failed.")
+
     if proc_stdout.startswith('Generated JWT'):
         proc_stdout = proc_stdout.split('\n',1)[1]
 
@@ -769,10 +773,10 @@ def get_notarization_state(request_id, build_info, options):
         output = readPlistFromString(proc_stdout.encode("UTF-8"))
     except ExpatError:
         print(proc_stderr, file=sys.stderr)
-        raise MunkiPkgError("Notarization check failed. Unable to run xcrun notarytool")
-    if retcode or 'message' not in output:
-        print("altool: " + output.get('success-message', 'Unexpected response'))
-        print("altool: DEBUG output follows")
+        raise MunkiPkgError("Notarization check failed.")
+    if 'message' not in output:
+        print("notarytool: " + output.get('success-message', 'Unexpected response'))
+        print("notarytool: DEBUG output follows")
         print(output)
         state['status'] = 'Unknown'
     else:
@@ -799,11 +803,9 @@ def notarization_done(state, sleep_time, options):
     else:
         display(
             "Notarization unsuccessful:\n"
-            "\tStatus: {}\n"
-            "\tStatus Code: {}\n"
-            "\tStatus Message: {}\n"
-            "\tLogFileURL: {}".format(
-                state['status'], state['code'], state['message'], state['log_url']
+            "\tStatus(id={}): {}\n"
+            "\tStatus Message: {}".format(
+                state['id'], state['status'], state['message']
             ),
             options.quiet,
         )

--- a/munkipkg
+++ b/munkipkg
@@ -683,52 +683,42 @@ def get_primary_bundle_id(build_info):
 
 def add_authentication_options(cmd, build_info):
     '''Add --password or --apiKey + --apiIssuer options to the command'''
-    if 'password' in build_info['notarization_info']:
+    if (
+        'apple_id' in build_info['notarization_info'] and
+        'password' in build_info['notarization_info']
+    ):
         cmd.extend(
-            ['--password', build_info['notarization_info']['password']]
+            '--apple-id', build_info['notarization_info']['apple_id'],
+            '--password', build_info['notarization_info']['password']
         )
     elif (
-          'api_key' in build_info['notarization_info'] and
-          'api_issuer' in build_info['notarization_info']
+          'keychain_profile' in build_info['notarization_info']
     ):
         cmd.extend(
             [
-                '--apiKey',
-                build_info['notarization_info']['api_key'],
-                '--apiIssuer',
-                build_info['notarization_info']['api_issuer'],
+                '--keychain-profile',
+                build_info['notarization_info']['keychain_profile']
             ]
         )
     else:
         raise MunkiPkgError(
-            "password or api_key + api_issuer keys "
+            "apple_id + password or keychain_profile"
             "must be specified in notarization_info."
         )
 
 
 def upload_to_notary(build_info, options):
-    '''Use xcrun altool to upload the package to Apple notary service'''
-    if 'username' not in build_info['notarization_info']:
-        raise MunkiPkgError("notarization_info lacks username key.")
+    '''Use xcrun notarytool to upload the package to Apple notary service'''
 
     display("Uploading package to Apple notary service", options.quiet)
     cmd = [
         XCRUN,
-        'altool',
-        '--notarize-app',
-        '--primary-bundle-id',
-        get_primary_bundle_id(build_info),
-        '--username',
-        build_info['notarization_info']['username'],
+        'notarytool',
+        'submit',
         '--output-format',
-        'xml',
-        '--file',
+        'plist',
         os.path.join(build_info['build_dir'], build_info['name']),
     ]
-    if 'asc_provider' in build_info['notarization_info']:
-        cmd.extend(
-            ['--asc-provider', build_info['notarization_info']['asc_provider']]
-        )
     add_authentication_options(cmd, build_info)
 
     retcode, proc_stdout, proc_stderr = run_subprocess(cmd)
@@ -747,32 +737,30 @@ def upload_to_notary(build_info, options):
                 file=sys.stderr
             )
         raise MunkiPkgError("Notarization failed")
-
+    
     try:
-        request_uuid = output['notarization-upload']['RequestUUID']
-        display("RequestUUID " + request_uuid, options.quiet, "altool")
-        display("SUCCESS " + output['success-message'], options.quiet, "altool")
+        request_id = output['id']
+        display("id " + request_id, options.quiet, "notarytool")
+        display(output['message'], options.quiet, "notarytool")
     except KeyError:
         raise MunkiPkgError("Unexpected output from altool")
 
-    return request_uuid
+    return request_id
 
 
-def get_notarization_state(request_uuid, build_info, options):
+def get_notarization_state(request_id, build_info, options):
     '''Checks for result of notarization process'''
     state = {}
     cmd = [
         XCRUN,
-        'altool',
-        '--notarization-info',
-        request_uuid,
-        '--username',
-        build_info['notarization_info']['username'],
+        'notarytool',
+        'info',
+        request_id,
         '--output-format',
-        'xml',
+        'plist',
     ]
     add_authentication_options(cmd, build_info)
-
+    
     retcode, proc_stdout, proc_stderr = run_subprocess(cmd)
     if proc_stdout.startswith('Generated JWT'):
         proc_stdout = proc_stdout.split('\n',1)[1]
@@ -781,26 +769,25 @@ def get_notarization_state(request_uuid, build_info, options):
         output = readPlistFromString(proc_stdout.encode("UTF-8"))
     except ExpatError:
         print(proc_stderr, file=sys.stderr)
-        raise MunkiPkgError("Notarization check failed. Unable to run xcrun altool")
-    if retcode or 'notarization-info' not in output:
+        raise MunkiPkgError("Notarization check failed. Unable to run xcrun notarytool")
+    if retcode or 'message' not in output:
         print("altool: " + output.get('success-message', 'Unexpected response'))
         print("altool: DEBUG output follows")
         print(output)
         state['status'] = 'Unknown'
     else:
-        state['log_url'] = output['notarization-info'].get('LogFileURL', '')
-        state['status'] = output['notarization-info'].get('Status', 'Unknown')
-        state['code'] = output['notarization-info'].get('Status Code', None)
-        state['message'] = output['notarization-info'].get('Status Message', '')
+        state['id'] = output.get('id', '')
+        state['status'] = output.get('status', 'Unknown')
+        state['message'] = output.get('message', '')
     return state
 
 
 def notarization_done(state, sleep_time, options):
     '''Evaluates whether notarization is still in progress'''
-    if state['status'] == 'success':
+    if state['status'] == 'Accepted':
         display("Notarization successful. {}".format(state['message']), options.quiet)
         return True
-    elif state['status'] in ['in progress', 'Unknown']:
+    elif state['status'] in ['In Progress', 'Unknown']:
         display(
             "Notarization state: {}. Trying again in {} seconds".format(
                 state['status'],
@@ -823,7 +810,7 @@ def notarization_done(state, sleep_time, options):
         raise MunkiPkgError("Notarization failed")
 
 
-def wait_for_notarization(request_uuid, build_info, options):
+def wait_for_notarization(request_id, build_info, options):
     '''Checks notarization state until it is done or we exceed the timeout value'''
     display("Getting notarization state", options.quiet)
     timeout = build_info['notarization_info'].get('staple_timeout', STAPLE_TIMEOUT)
@@ -835,7 +822,7 @@ def wait_for_notarization(request_uuid, build_info, options):
         counter += sleep_time
         sleep_time += STAPLE_SLEEP
 
-        state = get_notarization_state(request_uuid, build_info, options)
+        state = get_notarization_state(request_id, build_info, options)
 
         if notarization_done(state, sleep_time, options):
             return True
@@ -931,9 +918,9 @@ def build(project_dir, options):
         # notarize the pkg
         if 'notarization_info' in build_info and not options.skip_notarization:
             try:
-                request_uuid = upload_to_notary(build_info, options)
+                request_id = upload_to_notary(build_info, options)
                 if not options.skip_stapling and wait_for_notarization(
-                    request_uuid, build_info, options
+                    request_id, build_info, options
                 ):
                     staple(build_info, options)
             except MunkiPkgError as err:

--- a/munkipkg
+++ b/munkipkg
@@ -706,7 +706,7 @@ def add_authentication_options(cmd, build_info):
         )
     else:
         raise MunkiPkgError(
-            "apple_id + team_id + password or keychain_profile"
+            "apple_id + team_id + password or keychain_profile "
             "must be specified in notarization_info."
         )
 


### PR DESCRIPTION
Fixes the trailing space @YesThatAllen pointed out in #53. 

Also suggesting to merge to main, as the Apple notary service now officially no longer accepts uploads from altool, https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution.