### PR TITLE
Add `--skip-signing` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,9 @@ This option will import an existing package and convert it into a package projec
 `--export-bom-info`  
 This option causes munkipkg to export bom info from the built package to a file named "Bom.txt" in the root of the package project directory. Since git does not normally track ownership, group, or mode of tracked files, and since the "ownership" option to `pkgbuild` can also result in different owner and group of files included in the package payload, exporting this info into a text file allows you to track this metadata in git (or other version control) as well.
 
+`--skip-signing`
+Use this option to skip the whole signing process when signing is specified in the build-info.
+
 `--skip-notarization`  
 Use this option to skip the whole notarization process when notarization is specified in the build-info.
 

--- a/munkipkg
+++ b/munkipkg
@@ -578,7 +578,7 @@ def export_bom_info(build_info, options):
 
 def add_signing_options_to_cmd(cmd, build_info, options):
     '''If build_info contains signing options, add them to the cmd'''
-    if 'signing_info' in build_info:
+    if 'signing_info' in build_info and not options.skip_signing:
         display("Adding package signing info to command", options.quiet)
         signing_info = build_info['signing_info']
         if 'identity' in signing_info:
@@ -929,7 +929,7 @@ def build(project_dir, options):
             build_distribution_pkg(build_info, options)
 
         # notarize the pkg
-        if 'notarization_info' in build_info and not options.skip_notarization:
+        if 'notarization_info' in build_info and not options.skip_notarization and not options.skip_signing:
             try:
                 request_id = upload_to_notary(build_info, options)
                 if not options.skip_stapling and wait_for_notarization(
@@ -1264,6 +1264,9 @@ def main():
     parser.add_option('-f', '--force', action='store_true',
                       help='Forces creation of project directory if it already '
                            'exists. ')
+    parser.add_option('--skip-signing', action='store_true',
+                      help='Skips whole signing process when signing is '
+                           'specified in build-info')
     parser.add_option('--skip-notarization', action='store_true',
                       help='Skips whole notarization process when '
                            'notarization is specified in build-info')


### PR DESCRIPTION
This adds a `--skip-signing` option to allow users to bypass the package signing process.

When the `--skip-signing` flag is used, the signing (and notarization/stapling) steps are skipped, even if signing information is configured in the `build-info` file.