### PR TITLE
Add keychain option to notarization_info

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ Keys/values of the `notarization_info` dictionary:
 | team_id           | String  | (see authentication) | The team identifier for the Developer Team, usually 10 alphanumeric characters |
 | password          | String  | (see authentication) | 2FA app specific password. |
 | keychain_profile  | String  | (see authentication) | App Store Connect API key issuer ID. |
+| keychain          | String  | No       | Keychain file containing `keychain_profile`. |
 | asc_provider      | String  | No       | Only needed when a user account is associated with multiple providers |
 | primary_bundle_id | String  | No       | Defaults to `identifier`. Whether specified or not underscore characters are always automatically converted to hyphens since Apple notary service does not like underscores |
 | staple_timeout    | Integer | No       | See paragraph bellow |

--- a/munkipkg
+++ b/munkipkg
@@ -715,6 +715,13 @@ def add_authentication_options(cmd, build_info):
                 build_info['notarization_info']['keychain_profile']
             ]
         )
+        if 'keychain' in build_info['notarization_info']:
+            cmd.extend(
+                [
+                    '--keychain',
+                    build_info['notarization_info']['keychain']
+                ]
+            )
     else:
         raise MunkiPkgError(
             "apple_id + team_id + password or keychain_profile "


### PR DESCRIPTION
I ran into an issue where notarization did not work without also specifying the `keychain`. During troubleshooting, I noticed this output from the `notarytool store-credentials` command:

```
Credentials saved to Keychain.
To use them, specify `--keychain-profile "notarization_credentials" --keychain /path/to/custom_keychain.keychain-db`
```

When using a custom keychain (not login or system keychain), the credentials may not be available to `xcrun notarytool submit` without specifying the keychain location.

This change adds `keychain` as an optional key within `notarization_info` if `keychain_profile` is configured. It should not break any backwards compatibility.