### PR TITLE
Enhance installer options and fix Apple Silicon compatibility

### DIFF
--- a/munkipkg
+++ b/munkipkg
@@ -662,7 +662,7 @@ def build_distribution_pkg(build_info, options):
     dist_xml_content = f'''<?xml version="1.0" encoding="utf-8"?>
 <installer-gui-script minSpecVersion="1">
     <title>{title}</title>
-    <options customize="never" require-scripts="false"/>
+    <options customize="never" require-scripts="false" require-scripts="false" hostArchitectures="arm64,x86_64"/>
     <choices-outline>
         <line choice="default"/>
     </choices-outline>

--- a/munkipkg
+++ b/munkipkg
@@ -662,7 +662,7 @@ def build_distribution_pkg(build_info, options):
     dist_xml_content = f'''<?xml version="1.0" encoding="utf-8"?>
 <installer-gui-script minSpecVersion="1">
     <title>{title}</title>
-    <options customize="never" require-scripts="false" require-scripts="false" hostArchitectures="arm64,x86_64"/>
+    <options customize="never" require-scripts="false" hostArchitectures="arm64,x86_64"/>
     <choices-outline>
         <line choice="default"/>
     </choices-outline>


### PR DESCRIPTION
Fix to allow PKG's to be installed on Apple Silicon Macs without needing Rosetta